### PR TITLE
feat: Add Data tab with SQL and NoSQL sections

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,6 +135,28 @@
             <button
               type="button"
               class="sidebar-button"
+              data-target="data"
+            >
+              <span aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
+                  />
+                </svg>
+              </span>
+              Data
+            </button>
+            <button
+              type="button"
+              class="sidebar-button"
               data-target="statistics"
             >
               <span aria-hidden="true">
@@ -284,6 +306,163 @@
                   style="display: none"
                 >
                   <p>Failed to load collections. Please try again.</p>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <!-- Data Page -->
+          <div id="page-data" class="page-content" style="display: none">
+            <section class="data-panel">
+              <div class="data-header">
+                <h1 class="data-title">Data Management</h1>
+                <div class="data-tabs">
+                  <button type="button" class="data-tab is-active" data-tab="sql">SQL</button>
+                  <button type="button" class="data-tab" data-tab="nosql">NoSQL</button>
+                </div>
+              </div>
+
+              <!-- SQL Section -->
+              <div id="data-sql" class="data-section" style="display: flex;">
+                <div class="data-section-header">
+                  <h2>SQL Databases</h2>
+                  <p class="data-section-subtitle">Relational data in tabular format</p>
+                </div>
+                <div class="sql-container">
+                  <div class="sql-table-wrapper">
+                    <table class="sql-table">
+                      <thead>
+                        <tr>
+                          <th>Table Name</th>
+                          <th>Rows</th>
+                          <th>Size</th>
+                          <th>Last Updated</th>
+                          <th>Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody id="sql-tables-body">
+                        <tr>
+                          <td>users</td>
+                          <td>1,234</td>
+                          <td>2.5 MB</td>
+                          <td>2024-01-15</td>
+                          <td>
+                            <button type="button" class="ghost-button small">View</button>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>orders</td>
+                          <td>5,678</td>
+                          <td>8.2 MB</td>
+                          <td>2024-01-15</td>
+                          <td>
+                            <button type="button" class="ghost-button small">View</button>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>products</td>
+                          <td>890</td>
+                          <td>1.1 MB</td>
+                          <td>2024-01-14</td>
+                          <td>
+                            <button type="button" class="ghost-button small">View</button>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
+              <!-- NoSQL Section -->
+              <div id="data-nosql" class="data-section" style="display: none;">
+                <div class="data-section-header">
+                  <h2>NoSQL Databases</h2>
+                  <p class="data-section-subtitle">Document-based data with schema visualization</p>
+                </div>
+                <div class="nosql-container">
+                  <div class="nosql-diagram" id="nosql-diagram">
+                    <!-- Schema diagram will be rendered here -->
+                    <svg class="nosql-svg" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+                      <defs>
+                        <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+                          <polygon points="0 0, 10 3, 0 6" />
+                        </marker>
+                      </defs>
+                      <!-- Background -->
+                      <rect width="1200" height="800" fill="transparent" />
+                      
+                      <!-- Collection: cart -->
+                      <g class="collection-box" transform="translate(50, 50)">
+                        <rect x="0" y="0" width="200" height="180" rx="8" fill="var(--surface)" stroke="var(--border)" stroke-width="2" />
+                        <rect x="0" y="0" width="200" height="32" rx="8" fill="var(--accent)" />
+                        <text x="10" y="20" fill="white" font-size="14" font-weight="600">cart</text>
+                        <text x="10" y="55" fill="var(--text-primary)" font-size="12">_id (objectId NN)</text>
+                        <text x="10" y="75" fill="var(--text-primary)" font-size="12">date (date NN)</text>
+                        <text x="10" y="95" fill="var(--text-primary)" font-size="12">total_value (double)</text>
+                        <text x="10" y="115" fill="var(--text-primary)" font-size="12">item {} (object NN)</text>
+                        <text x="10" y="135" fill="var(--text-primary)" font-size="12">customer (objectId NN)</text>
+                        <text x="10" y="155" fill="var(--text-primary)" font-size="12">coupon_code (string)</text>
+                      </g>
+
+                      <!-- Collection: product -->
+                      <g class="collection-box" transform="translate(700, 50)">
+                        <rect x="0" y="0" width="200" height="140" rx="8" fill="var(--surface)" stroke="var(--border)" stroke-width="2" />
+                        <rect x="0" y="0" width="200" height="32" rx="8" fill="var(--accent)" />
+                        <text x="10" y="20" fill="white" font-size="14" font-weight="600">product</text>
+                        <text x="10" y="55" fill="var(--text-primary)" font-size="12">_id (objectId NN)</text>
+                        <text x="10" y="75" fill="var(--text-primary)" font-size="12">name (string NN)</text>
+                        <text x="10" y="95" fill="var(--text-primary)" font-size="12">sku (string NN)</text>
+                        <text x="10" y="115" fill="var(--text-primary)" font-size="12">price {} (object)</text>
+                      </g>
+
+                      <!-- Collection: customer -->
+                      <g class="collection-box" transform="translate(50, 400)">
+                        <rect x="0" y="0" width="200" height="140" rx="8" fill="var(--surface)" stroke="var(--border)" stroke-width="2" />
+                        <rect x="0" y="0" width="200" height="32" rx="8" fill="var(--accent)" />
+                        <text x="10" y="20" fill="white" font-size="14" font-weight="600">customer</text>
+                        <text x="10" y="55" fill="var(--text-primary)" font-size="12">_id (objectId NN)</text>
+                        <text x="10" y="75" fill="var(--text-primary)" font-size="12">name (string NN)</text>
+                        <text x="10" y="95" fill="var(--text-primary)" font-size="12">surname (string NN)</text>
+                        <text x="10" y="115" fill="var(--text-primary)" font-size="12">contact {} (object)</text>
+                      </g>
+
+                      <!-- Embedded: item {} -->
+                      <g class="embedded-box" transform="translate(350, 150)">
+                        <rect x="0" y="0" width="180" height="120" rx="6" fill="var(--surface-muted)" stroke="var(--border)" stroke-width="1.5" stroke-dasharray="4,2" />
+                        <text x="10" y="20" fill="var(--text-secondary)" font-size="12" font-weight="600">item {}</text>
+                        <text x="10" y="45" fill="var(--text-primary)" font-size="11">product_id (objectId)</text>
+                        <text x="10" y="65" fill="var(--text-primary)" font-size="11">name (string)</text>
+                        <text x="10" y="85" fill="var(--text-primary)" font-size="11">qty (int)</text>
+                        <text x="10" y="105" fill="var(--text-primary)" font-size="11">price (double)</text>
+                      </g>
+
+                      <!-- Embedded: price {} -->
+                      <g class="embedded-box" transform="translate(950, 150)">
+                        <rect x="0" y="0" width="180" height="100" rx="6" fill="var(--surface-muted)" stroke="var(--border)" stroke-width="1.5" stroke-dasharray="4,2" />
+                        <text x="10" y="20" fill="var(--text-secondary)" font-size="12" font-weight="600">price {}</text>
+                        <text x="10" y="45" fill="var(--text-primary)" font-size="11">list_price (double)</text>
+                        <text x="10" y="65" fill="var(--text-primary)" font-size="11">valid_from (date)</text>
+                        <text x="10" y="85" fill="var(--text-primary)" font-size="11">valid_to (date)</text>
+                      </g>
+
+                      <!-- Embedded: contact {} -->
+                      <g class="embedded-box" transform="translate(350, 500)">
+                        <rect x="0" y="0" width="180" height="80" rx="6" fill="var(--surface-muted)" stroke="var(--border)" stroke-width="1.5" stroke-dasharray="4,2" />
+                        <text x="10" y="20" fill="var(--text-secondary)" font-size="12" font-weight="600">contact {}</text>
+                        <text x="10" y="45" fill="var(--text-primary)" font-size="11">address {} (object)</text>
+                        <text x="10" y="65" fill="var(--text-primary)" font-size="11">phones {} (object)</text>
+                      </g>
+
+                      <!-- Relationship lines -->
+                      <line x1="250" y1="140" x2="350" y2="150" stroke="var(--border-strong)" stroke-width="2" stroke-dasharray="5,3" />
+                      <line x1="250" y1="230" x2="350" y2="210" stroke="var(--border-strong)" stroke-width="2" stroke-dasharray="5,3" />
+                      <line x1="900" y1="140" x2="950" y2="150" stroke="var(--border-strong)" stroke-width="2" stroke-dasharray="5,3" />
+                      <line x1="250" y1="540" x2="350" y2="500" stroke="var(--border-strong)" stroke-width="2" stroke-dasharray="5,3" />
+                      <line x1="530" y1="200" x2="700" y2="120" stroke="var(--accent)" stroke-width="2" />
+                      <line x1="250" y1="400" x2="250" y2="400" stroke="var(--accent)" stroke-width="2" />
+                    </svg>
+                  </div>
                 </div>
               </div>
             </section>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1464,3 +1464,259 @@ body {
   }
 }
 
+/* Data Page Styles */
+.data-panel {
+  background: var(--surface);
+  border-radius: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: clamp(24px, 3vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 3vw, 32px);
+}
+
+.data-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.data-title {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 700;
+}
+
+.data-tabs {
+  display: flex;
+  gap: 8px;
+  background: var(--surface-muted);
+  padding: 4px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.data-tab {
+  all: unset;
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  pointer-events: auto;
+  user-select: none;
+}
+
+.data-tab:hover {
+  color: var(--text-primary);
+  background: var(--surface);
+}
+
+.data-tab.is-active {
+  background: var(--surface);
+  color: var(--accent);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.data-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+}
+
+.data-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.data-section-header h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.data-section-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+/* SQL Table Styles */
+.sql-container {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.sql-table-wrapper {
+  background: var(--surface-muted);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.sql-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+}
+
+.sql-table thead {
+  background: var(--surface-muted);
+}
+
+.sql-table th {
+  padding: 16px 20px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 2px solid var(--border);
+}
+
+.sql-table td {
+  padding: 16px 20px;
+  font-size: 14px;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border);
+}
+
+.sql-table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.sql-table tbody tr:hover {
+  background: var(--surface-muted);
+}
+
+.sql-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.ghost-button.small {
+  padding: 6px 14px;
+  font-size: 13px;
+  height: auto;
+}
+
+/* NoSQL Diagram Styles */
+.nosql-container {
+  width: 100%;
+  overflow: auto;
+  background: var(--surface-muted);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 24px;
+  min-height: 600px;
+}
+
+.nosql-diagram {
+  width: 100%;
+  height: 100%;
+  min-height: 600px;
+  position: relative;
+}
+
+.nosql-svg {
+  width: 100%;
+  height: 100%;
+  min-height: 600px;
+}
+
+.nosql-svg .collection-box rect:first-of-type {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+  fill: var(--surface);
+  stroke: var(--border);
+}
+
+.nosql-svg .collection-box rect:last-of-type {
+  fill: var(--accent);
+}
+
+.nosql-svg .embedded-box rect {
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.08));
+  fill: var(--surface-muted);
+  stroke: var(--border);
+}
+
+.nosql-svg .collection-box text:first-of-type {
+  fill: white;
+}
+
+.nosql-svg .collection-box text:not(:first-of-type) {
+  fill: var(--text-primary);
+}
+
+.nosql-svg .embedded-box text:first-of-type {
+  fill: var(--text-secondary);
+}
+
+.nosql-svg .embedded-box text:not(:first-of-type) {
+  fill: var(--text-primary);
+}
+
+.nosql-svg line[stroke="var(--border-strong)"],
+.nosql-svg line[stroke*="border-strong"] {
+  stroke: var(--border-strong);
+}
+
+.nosql-svg line[stroke="var(--accent)"],
+.nosql-svg line[stroke*="accent"] {
+  stroke: var(--accent);
+}
+
+.nosql-svg line {
+  marker-end: url(#arrowhead);
+}
+
+.nosql-svg defs marker#arrowhead {
+  fill: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .data-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .data-tabs {
+    width: 100%;
+  }
+
+  .data-tab {
+    flex: 1;
+    text-align: center;
+  }
+
+  .sql-table {
+    font-size: 12px;
+  }
+
+  .sql-table th,
+  .sql-table td {
+    padding: 12px 14px;
+  }
+
+  .nosql-container {
+    padding: 16px;
+    min-height: 400px;
+  }
+
+  .nosql-diagram {
+    min-height: 400px;
+  }
+
+  .nosql-svg {
+    min-height: 400px;
+  }
+}
+


### PR DESCRIPTION
- Add Data sidebar button before Statistics
- Create Data page with SQL and NoSQL tabs
- SQL section: Tabular format showing database tables
- NoSQL section: Schema diagram visualization with collections and embedded documents
- Add CSS styles for data page, tabs, SQL table, and NoSQL diagram
- Add JavaScript functionality for tab switching and theme-aware diagram colors
- Responsive design for mobile devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Data management page accessible from the sidebar navigation.
  * Data page includes SQL and NoSQL tabs for viewing database information.
  * SQL tab displays sample databases in a table format with view actions.
  * NoSQL tab presents database collections in a visual diagram.
  * Data visualizations automatically adjust to match your selected theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->